### PR TITLE
Fixed readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ metadata:
   name: godaddy-api-key
 type: Opaque
 stringData:
-  key: <GODADDY_API:GODADDY_SECRET>
+  token: <GODADDY_API:GODADDY_SECRET>
 EOF
 ```
 - Next, deploy it under the namespace where you would like to get your certificate/key signed by the ACME CA Authority

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ cat <<EOF > secret.yml
 apiVersion: v1
 kind: Secret
 metadata:
-  name: gadaddy-api-key
+  name: godaddy-api-key
 type: Opaque
 stringData:
   key: <GODADDY_API:GODADDY_SECRET>


### PR DESCRIPTION
There was a typo in the name of the secret and also the key: in cluster issuer is referred as token