### PR TITLE
fix(logging): Sync logging options to cert-manager runtime

### DIFF
--- a/deploy/charts/godaddy-webhook/templates/deployment.yaml
+++ b/deploy/charts/godaddy-webhook/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $logLevels := dict "fatal" 0 "panic" 0 "error" 0 "warn" 1 "info" 2 "debug" 4 "trace" 5 -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -29,6 +30,10 @@ spec:
             - --tls-cert-file=/tls/tls.crt
             - --tls-private-key-file=/tls/tls.key
             - --secure-port={{ default 443 .Values.pod.securePort }}
+            - --v {{ index $logLevels .Values.logging.level }}
+            {{- if or (eq .Values.logging.format "text") (eq .Values.logging.format "json") }}
+            - --logging-format={{ .Values.logging.format }}
+            {{- end }}
           env:
             - name: GROUP_NAME
               value: {{ .Values.groupName | quote }}


### PR DESCRIPTION
- Sync logging format and log level configuration to the logger used by the cert-manager runtime

Fixes #49 

This change will ensure that the logging options passed to the webhook controller are also used by the cert-manager runtime